### PR TITLE
Add "contents" interface to the componant

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Include ```typeahead.js``` and ```ember-typeahead.js```
 Add the typeahead tag in your handlebars template
 
 ```
-{{type-ahead data=content name="colour" selection=myColour}}
+{{type-ahead data=content name="colour" selection=myColour contents=inputContents}}
 ```
 
 ## Properties
@@ -30,6 +30,7 @@ Add the typeahead tag in your handlebars template
 - ```data``` An array of ember objects used for the lookup. This can also be a promise that resolves to an array
 - ```name``` The name of the property on the ember object which is to be displayed
 - ```selection``` Binds the selected value. This changes on the ```typeahead:selected``` and ```typeahead:autocompleted``` events (see [typeahead.js custom events](https://github.com/twitter/typeahead.js/#custom-events))
+- ```contents``` The value of the input updated on the keyup event of the input
 
 ## Tests
 

--- a/src/main.js
+++ b/src/main.js
@@ -24,8 +24,9 @@
 
     initializeTypeahead: function(data){
       var _this = this;
-      this.typeahead = this.$().typeahead({
-        name: _this.$().attr('id') || "typeahead",
+      var $input = this.$();
+      this.typeahead = $input.typeahead({
+        name: $input.attr('id') || "typeahead",
         limit: this.get("limit") || 5,
         local: data.map(function(item) {
           return {
@@ -35,6 +36,10 @@
             emberObject: item
           };
         })
+      });
+
+      this.typeahead.on("keyup", function() {
+        _this.set("contents", $input.val());
       });
 
       this.typeahead.on("typeahead:selected", function(event, item) {


### PR DESCRIPTION
This PR adds a contents interface that allows you to bind to the actual value of the input.

This is useful for the case where you want access to the text content inside of the type ahead. My use case is to create a type ahead that allows users to select an existing entity, or create a new one.

I tested this in the application I am currently working on, and it works without regressions.

I also updated the readme to document this feature.

I did not build the dist, or bump the version as I figured I'd let the maintainer do the honors, but this does feel like a minor version bump to me.

While I was at it, I also cached the jQuery input selection for better performance.
