### PR TITLE
Document extending Ember.TextField

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Add the typeahead tag in your handlebars template
 {{type-ahead data=content name="colour" selection=myColour}}
 ```
 
+Since `ember-typeahead` extends `Ember.TextField`, you can still bind other properties such as `value` and `action`:
+
+```
+{{type-ahead data=content name="colour" selection=myColour action=createNewColour value=colourText}}
+```
+
 ## Properties
 
 - ```data``` An array of ember objects used for the lookup. This can also be a promise that resolves to an array


### PR DESCRIPTION
The comment in #13 helped me. This might be super obvious to people who are more accustomed to Ember, but having these extra lines make it even more explicit.
